### PR TITLE
Add optional argcomplete support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 ## Installation
 
 ```bash
+# Without argcomplete support
 pip install git+https://github.com/vipyrsec/vipyrsec-deobfuscator.git
+# With argcomplete support
+pip install "vipyr-deobf[argcomplete] @ git+https://github.com/vipyrsec/vipyrsec-deobfuscator.git"
 ```
 
 ## Supported Obfuscation Types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "pycryptodome",
 ]
 
+[project.optional-dependencies]
+argcomplete = ["argcomplete"]
+
 [project.urls]
 repository = "https://github.com/vipyrsec/vipyrsec-deobfuscator/"
 

--- a/src/vipyr_deobf/cli.py
+++ b/src/vipyr_deobf/cli.py
@@ -112,7 +112,7 @@ def run():
     )
     parser.add_argument('path', help='path to obfuscated file')
     parser.add_argument('-t', '--type', default='auto', type=str,
-                        choices=list(supported_obfuscators.keys()).append('auto'),
+                        choices=list(supported_obfuscators.keys())+['auto'],
                         help='type of obfuscation used (defaults to auto)')
     parser.add_argument('-o', '--output', help='file to output deobf result to, defaults to stdout')
     parser.add_argument('-d', '--debug', action='store_true', help='display debug logs (defaults to false)')

--- a/src/vipyr_deobf/cli.py
+++ b/src/vipyr_deobf/cli.py
@@ -1,6 +1,8 @@
+# PYTHON_ARGCOMPLETE_OK
 import argparse
 import logging
 import logging.config
+import importlib.util
 from typing import Callable, TypeVar
 
 from .deobfuscators.blankobf2 import deobf_blankobf2, format_blankobf2
@@ -109,10 +111,15 @@ def run():
         description='Deobfuscates obfuscated scripts',
     )
     parser.add_argument('path', help='path to obfuscated file')
-    parser.add_argument('-t', '--type', default='auto', help='type of obfuscation used (defaults to auto)')
+    parser.add_argument('-t', '--type', default='auto', type=str,
+                        choices=list(supported_obfuscators.keys()).append('auto'),
+                        help='type of obfuscation used (defaults to auto)')
     parser.add_argument('-o', '--output', help='file to output deobf result to, defaults to stdout')
     parser.add_argument('-d', '--debug', action='store_true', help='display debug logs (defaults to false)')
     parser.add_argument('-s', '--soft', action='store_true', help='display expected warnings (defaults to false)')
+    if importlib.util.find_spec('argcomplete') is not None:
+        import argcomplete
+        argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     logger = logging.getLogger('deobf')


### PR DESCRIPTION
For users with `argcomplete` installed, they can have some form of tab-completion, especially for the `--type` option.

Limitations: Without needing to optimize imports to only import modules when necessary, `argcomplete` may feel sluggish due to it needing to evaluate the script up until the `parser` is created. This seems to be a problem with global completion, and there's not much to fix it besides refactoring to move the `parser` to invoked as quickly as possible.

Follow-ups: Rewriting `README.md` to address `argcomplete` support in a better fashion.

Example terminal output (`argcomplete` installed):
![2024-08-07_15-42](https://github.com/user-attachments/assets/d3b1b96e-c5c6-472a-a7c0-a9b7e12f01cd)
![image](https://github.com/user-attachments/assets/d1ccaa3f-3cb9-4a73-8c3c-03d6fe12af03)

Default terminal output (`argcomplete` uninstalled):
![2024-08-07_15-49](https://github.com/user-attachments/assets/a73b6f18-7c53-4eca-9bd1-39bcd036456a)
